### PR TITLE
Adding a note about pip3 to the Install PlasmaPy section of the main page

### DIFF
--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -85,6 +85,8 @@ PlasmaPy may be installed from the command line using [`pip`](https://pip.pypa.i
 pip install plasmapy
 ```
 
+Note: if you run into difficulty using pip, you may also try using pip3 as the command.
+
 If you have a working installation of [conda](https://docs.conda.io/en/latest/), then you may install PlasmaPy with
 
 ```shell


### PR DESCRIPTION
Added a note about using pip3 as a command if the user runs into problems using pip as the command.